### PR TITLE
Use `readr::write_csv(file =)` instead of `path`

### DIFF
--- a/R/write_byperson.R
+++ b/R/write_byperson.R
@@ -91,7 +91,7 @@ write_byperson <- function(data, sg_crit1_cutoff, id_var_name, sg_var_list, tx_s
 
     # Write bysg data in the specified format
     if (format == "CSV") {
-        readr::write_csv(x = byperson_data, path = path, ...)
+        readr::write_csv(x = byperson_data, file = path, ...)
     } else if (format == "SPSS") {
         haven::write_sav(data = byperson_data, path = path, ...)
     } else if (format == "Excel") {

--- a/R/write_bysg.R
+++ b/R/write_bysg.R
@@ -85,7 +85,7 @@ write_bysg <- function(data, sg_crit1_cutoff, id_var_name, sg_var_list, tx_start
 
     # Write bysg data in the specified format
     if (format == "CSV") {
-        readr::write_csv(x = bysg_data, path = path, ...)
+        readr::write_csv(x = bysg_data, file = path, ...)
     } else if (format == "SPSS") {
         haven::write_sav(data = bysg_data, path = path, ...)
     } else if (format == "Excel") {


### PR DESCRIPTION
The `path` argument will be removed from `readr::write_*()` in its next release. It has been deprecated for over 5 years, since readr 1.4.0 (2020-01-31). Since that time, any `path` value has just been passed along as `file`, which is what this PR does.

This is part of a bigger effort to advance a bunch of deprecation processes that started 4+ years ago: <https://github.com/tidyverse/readr/issues/1600>. I released readr v2.1.6 on 2025-11-14 and have no immediate plans for another release. I just wanted to advanced these deprecations right away, to give downstream dependencies plenty of time to adjust.

I am also sending an email to the maintainer listed in DESCRIPTION. 